### PR TITLE
Remove deprecated curl_close() call (no-op since PHP 8.0)

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -296,7 +296,12 @@ class Instagram
             throw new InstagramException('Error: _makeCall() - cURL error: ' . curl_error($ch), curl_errno($ch));
         }
 
-        curl_close($ch);
+        if (PHP_VERSION_ID >= 80000) {
+            unset($ch);
+        } else {
+            curl_close($ch);
+        }
+
         return json_decode($jsonData);
     }
 


### PR DESCRIPTION
`curl_close()` has been a no-op since PHP 8.0 (when curl resources were migrated to `CurlHandle` objects) and is now [formally deprecated in PHP 8.5](https://php.watch/versions/8.5/curl_close-curl_share_close-deprecated), emitting:

> Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0

This PR replaces the `curl_close($ch)` call with a version check following the [recommended replacement pattern from php.watch](https://php.watch/versions/8.5/curl_close-curl_share_close-deprecated#replacement):

- **PHP >= 8.0**: `unset($ch)` to explicitly destroy the `CurlHandle` object
- **PHP < 8.0**: `curl_close($ch)` to properly free the resource

This maintains backward compatibility with the package's `>=5.6` PHP requirement.